### PR TITLE
Remove "draft" status from Threat Model

### DIFF
--- a/threat-model/readme.md
+++ b/threat-model/readme.md
@@ -3,7 +3,9 @@
 
 ## Document Status
 
-This is a living document which represents the current working threat model for the PATCG (and eventually PATWG.) It has received feedback both on Github and in regular PATCG meetings. Not all issues are resolved, and new issues raised against it are to be expected. However, the document is a fair representation of the threats currently considered for proposals within the PATCG.
+This document represents the current working threat model for the PATCG (and eventually PATWG.) It has received feedback both on Github and in regular PATCG meetings. Not all issues are resolved, and new issues raised against it are to be expected. However, the document is a fair representation of the threats currently considered for proposals within the PATCG.
+
+This document concentrates primarily on security topics. Privacy goals and principles are the subject of [a separate document](https://patcg.github.io/docs-and-reports/principles/).
 
 
 ## Introduction

--- a/threat-model/readme.md
+++ b/threat-model/readme.md
@@ -1,9 +1,9 @@
 # Security Considerations
 
 
-## Document Status: DRAFT
+## Document Status
 
-This document is currently a **draft**, submitted to the PATCG (and eventually the PATWG) with the intention of receiving broad feedback. In this state, it does not yet represent any form of consensus in either group, nor should it be seen as a specific endorsement from any contributors. This document will likely evolve significantly through the consensus process.
+This is a living document which represents the current working threat model for the PATCG (and eventually PATWG.) It has received feedback both on Github and in regular PATCG meetings. Not all issues are resolved, and new issues raised against it are to be expected. However, the document is a fair representation of the threats currently considered for proposals within the PATCG.
 
 
 ## Introduction


### PR DESCRIPTION
The threat model document has received a great deal of feedback, and I'd like to consider removing the "draft" status at the top. I've replaced that language with new language to make it clear this is still a living document and not finalized, but removed the language that it's only provided for feedback.

I'm not sure if there is a formal process by which we want to move this to any next stage, nor do I think we need to finalize this document at this point (it should be a living document for the foreseeable future.) However, I do believe this is a fair representation of our internal soft consensus and the document no longer needs the same disclaimer at the top.