### PR TITLE
Consensus on server-side data join

### DIFF
--- a/design-dimensions/Dimensions-with-General-Agreement.md
+++ b/design-dimensions/Dimensions-with-General-Agreement.md
@@ -16,7 +16,7 @@ The community group has reached general agreement that the _Private Measurement 
 
 ### Location of Data Join
 
-The community group has reached general agreement that data join could potentially occur off device within a some type of server side architecture.
+Attribution requires joining data from the site of an impression (source) and the site of a conversion (trigger). The community group has reached general agreement that data join could potentially occur off device within a some type of server side architecture.
 This is conditional on having adequate protections for any data that leaves a device, in line with our security and privacy goals.
 
 ## Privacy defined at least by Differential Privacy

--- a/design-dimensions/Dimensions-with-General-Agreement.md
+++ b/design-dimensions/Dimensions-with-General-Agreement.md
@@ -14,6 +14,10 @@ This document serves to capture the dimensions with general agreement from the C
 
 The community group has reached general agreement that the _Private Measurement Technical Specification MVP_ may include server processing dependencies, however any server architecture must achieve both a high level of security (which the editors will align with the ongoing [Threat Model](../threat-model) work) as well as ability to explain the privacy and security properties of the system to end users.
 
+### Location of Data Join
+
+The community group has reached general agreement that data join could potentially occur off device within a some type of server side architecture.
+This is conditional on having adequate protections for any data that leaves a device, in line with our security and privacy goals.
 
 ## Privacy defined at least by Differential Privacy
 


### PR DESCRIPTION
At the last face-to-face PAT-CG call, we discussed this design dimension: the location of data join (between source and trigger events).

There was consensus that the group was potentially open to data join happening server-side, so long as the system was able to achieve our desired privacy and security goals.