### PR TITLE
list Nick Doty as current editor of Private Ad Technologies Principles

### DIFF
--- a/principles/index.html
+++ b/principles/index.html
@@ -9,6 +9,12 @@
       specStatus: 'CG-DRAFT',
       group: 'patcg',
       editors: [
+        {
+          name: "Nick Doty",
+          url: "https://npdoty.name",
+          company: "Center for Democracy & Technology",
+          companyURL: "https://cdt.org"
+        }
       ],
       github: 'patcg/docs-and-reports',
       shortName: 'pat-principles',
@@ -51,6 +57,9 @@
       door open to a variety of approaches so that different use cases can be approached with some flexibility.
       This document is therefore more specific in detailing how the Web's broader privacy principles are to be
       understood in an advertising context.
+    </p>
+    <p>
+      The Private Ad Technologies Community Group also maintains a <a href="https://github.com/patcg/docs-and-reports/tree/main/threat-model">working threat model</a>, with security and privacy threats.
     </p>
   </section>
 


### PR DESCRIPTION
and add link to threat model in How This Document Fits In